### PR TITLE
Add unread indicators for followed content

### DIFF
--- a/chronicles.js
+++ b/chronicles.js
@@ -271,7 +271,7 @@ function renderChroniclesList() {
 
   document.getElementById('chr-count-badge').textContent = total ? `(${total})` : '';
 
-  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
+  unreadIndicators.refreshNav();
   if (!total) { grid.innerHTML = ''; empty.style.display = 'flex'; return; }
   empty.style.display = 'none';
   grid.innerHTML = [
@@ -304,9 +304,7 @@ function chrCardHTML(id, c, isFollowed) {
 
   if (isFollowed) {
     const entryIds = (chrEntries[id] || []).map(e => e.id);
-    const hasUnreadEntry = unreadMarkers.chronicleHasUnreadEntries(id, entryIds, false);
-    const showUnread = unreadMarkers.isChronicleUnread(id, false) || hasUnreadEntry;
-    return `<div class="chr-card" onclick="showChrDetail('${id}')">${unreadMarkers.cardDotHTML(showUnread)}
+    return `<div class="chr-card" onclick="showChrDetail('${id}')">${unreadIndicators.chronicleCardDotHTML(id, entryIds)}
       ${c.illustration_url ? `<img class="card-illus" src="${esc(c.illustration_url)}" style="object-position:center ${c.illustration_position||0}%" onclick="event.stopPropagation();openLightbox('${esc(c.illustration_url)}')" alt="">` : ''}
       <div class="chr-card-actions">
         <button class="icon-btn danger" onclick="event.stopPropagation();unfollowChronicle('${id}')" title="${t('btn_unsubscribe')}">
@@ -355,8 +353,7 @@ async function showChrDetail(chrId) {
   await loadEntriesForChronicle(chrId);
   renderChrDetail();
   showView('chr-detail');
-  if (!chronicles[chrId]) unreadMarkers.markChronicleRead(chrId);
-  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
+  unreadIndicators.markChronicleOpened(chrId, !!chronicles[chrId]);
   const chr = chronicles[chrId] || followedChronicles[chrId];
   if (chr?.share_code) setHash('chr', chr.share_code);
 }
@@ -408,7 +405,7 @@ function entryRowHTML(e, isOwn, chrId) {
     : '';
   const preview = (e.content || '').replace(/#+\s*/g,'').replace(/\*+/g,'').replace(/\n/g,' ').slice(0, 160);
 
-  const unreadDot = unreadMarkers.entryDotHTML(unreadMarkers.isEntryUnread(chrId, e.id, isOwn));
+  const unreadDot = isOwn ? '' : unreadIndicators.entryRowDotHTML(chrId, e.id);
   return `<div class="entry-row" onclick="openEntryReader('${e.id}')">${unreadDot}
     <div class="entry-row-header">
       <div class="entry-row-title">${esc(e.title)}</div>
@@ -584,8 +581,7 @@ function openEntryReader(entryId) {
     <div class="chr-reader-body">${entry.content ? renderMarkdown(entry.content) : ''}</div>
   `;
   showView('entry-reader');
-  if (!chronicles[activeChrId]) unreadMarkers.markEntryRead(activeChrId, entryId);
-  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
+  unreadIndicators.markChronicleEntryOpened(activeChrId, entryId, !!chronicles[activeChrId]);
   const chrShareCode = (chronicles[activeChrId] || followedChronicles[activeChrId])?.share_code;
   if (chrShareCode) setHash('entry', chrShareCode, entryId);
 }

--- a/documents.js
+++ b/documents.js
@@ -233,6 +233,7 @@ function renderDocumentsList() {
   }
   const total = Object.keys(documents).length + Object.keys(followedDocuments).length;
   document.getElementById('doc-count-badge').textContent = total ? `(${total})` : '';
+  unreadIndicators.refreshNav();
   const allKeys = [...ownKeys, ...followedKeys];
   if (!allKeys.length) { grid.innerHTML = ''; empty.style.display = 'flex'; return; }
   empty.style.display = 'none';
@@ -296,6 +297,7 @@ function docCardHTML(id, d, isFollowed) {
       return tg ? `<span class="tag-chip" style="background:${tg.color}22;color:${tg.color};border:1px solid ${tg.color}44">${esc(tg.name)}</span>` : '';
     }).join('');
     return `<div class="doc-card" onclick="openDocReader('${id}')">
+      ${unreadIndicators.documentCardDotHTML(id)}
       ${d.illustration_url ? `<img class="card-illus" src="${esc(d.illustration_url)}" style="object-position:center ${d.illustration_position||0}%" onclick="event.stopPropagation();openLightbox('${esc(d.illustration_url)}')" alt="">` : ''}
       <div class="doc-card-actions">
         <button class="icon-btn" onclick="event.stopPropagation();editFollowedDocTags('${id}')" title="${t('card_manage_tags')}">
@@ -543,6 +545,7 @@ function openDocReader(id) {
     : `<div id="doc-reader-content">${contentHtml}</div>`;
 
   showView('doc-reader');
+  unreadIndicators.markDocumentOpened(id, isOwn);
   if (d.share_code) setHash('doc', d.share_code);
 
   // ── Scroll spy ────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -1048,6 +1048,7 @@
 </script>
 <script src="supabase-client.js"></script>
 <script src="unread-markers.js"></script>
+<script src="unread-indicators.js"></script>
 <script src="chronicles.js"></script>
 <script src="documents.js"></script>
 <script src="campaigns.js"></script>

--- a/scripts.js
+++ b/scripts.js
@@ -287,6 +287,7 @@ async function init() {
 
 async function onSignedIn(user) {
   currentUser = user;
+  await unreadMarkers.initFromDB(user.id);
   updateUserUI(currentUser);
   const username = user.user_metadata?.full_name || user.user_metadata?.name
     || user.user_metadata?.username || user.email?.split('@')[0] || 'Joueur';
@@ -312,6 +313,7 @@ async function onSignedIn(user) {
 
 function onSignedOut() {
   currentUser = null; chars = {};
+  unreadMarkers.resetCache();
   document.getElementById('loading-overlay').classList.remove('active');
   document.getElementById('auth-screen').classList.add('active');
   document.getElementById('app').style.display = 'none';
@@ -388,6 +390,7 @@ function renderList() {
   }
   const total = Object.keys(chars).length + Object.keys(followedChars).length;
   document.getElementById('list-count-badge').textContent = total ? `(${total})` : '';
+  unreadIndicators.refreshNav();
   const grid  = document.getElementById('char-grid');
   const empty = document.getElementById('empty-state');
   const allKeys = [...keys, ...followedKeys];
@@ -411,6 +414,7 @@ function cardHTML(id, c, isFollowed = false) {
       return tg ? `<span class="tag-chip" style="background:${tg.color}22;color:${tg.color};border:1px solid ${tg.color}44">${esc(tg.name)}</span>` : '';
     }).join('');
     return `<div class="char-card" onclick="showSharedChar(followedChars['${id}'])">
+      ${unreadIndicators.characterCardDotHTML(id)}
       ${c.illustration_url ? `<img class="card-illus" src="${esc(c.illustration_url)}" style="object-position:center ${c.illustration_position||0}%" onclick="event.stopPropagation();openLightbox('${esc(c.illustration_url)}')" alt="">` : ''}
       <div class="card-actions">
         <button class="icon-btn" onclick="event.stopPropagation();editFollowedTags('${id}')" title="${t('card_manage_tags')}">
@@ -550,6 +554,8 @@ function showSharedChar(data) {
   `;
   showView('shared');
   currentSharedCharCode = data.share_code || null;
+  const followedId = Object.keys(followedChars).find(id => followedChars[id] === data);
+  unreadIndicators.markCharacterOpened(followedId, !followedId);
   if (data.share_code) setHash('char', data.share_code);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -134,6 +134,39 @@ html, body {
 }
 #topbar nav button:hover { color: var(--text); background: var(--bg3); }
 #topbar nav button.active { color: var(--accent); background: var(--bg3); }
+#topbar nav button { position: relative; }
+
+.unread-dot {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--accent);
+  border: 2px solid var(--bg2);
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.08);
+}
+
+.unread-dot-card {
+  top: 10px;
+  right: 10px;
+  z-index: 6;
+}
+
+.unread-dot-entry {
+  top: 10px;
+  right: 10px;
+  z-index: 2;
+}
+
+.nav-unread-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--accent);
+}
 
 @media (max-width: 768px) {
   #topbar nav button { padding: 5px 10px; font-size: 11px; }

--- a/unread-indicators.js
+++ b/unread-indicators.js
@@ -1,0 +1,59 @@
+(function () {
+  function refreshNav() {
+    unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
+  }
+
+  function characterCardDotHTML(id) {
+    return unreadMarkers.cardDotHTML(unreadMarkers.isCharacterUnread(id, false));
+  }
+
+  function documentCardDotHTML(id) {
+    return unreadMarkers.cardDotHTML(unreadMarkers.isDocumentUnread(id, false));
+  }
+
+  function chronicleCardDotHTML(chrId, entryIds) {
+    const hasUnreadEntry = unreadMarkers.chronicleHasUnreadEntries(chrId, entryIds, false);
+    const showUnread = unreadMarkers.isChronicleUnread(chrId, false) || hasUnreadEntry;
+    return unreadMarkers.cardDotHTML(showUnread);
+  }
+
+  function entryRowDotHTML(chrId, entryId) {
+    return unreadMarkers.entryDotHTML(unreadMarkers.isEntryUnread(chrId, entryId, false));
+  }
+
+  function markCharacterOpened(id, isOwn) {
+    if (isOwn || !id) return;
+    unreadMarkers.markCharacterRead(id);
+    refreshNav();
+  }
+
+  function markDocumentOpened(id, isOwn) {
+    if (isOwn || !id) return;
+    unreadMarkers.markDocumentRead(id);
+    refreshNav();
+  }
+
+  function markChronicleOpened(id, isOwn) {
+    if (isOwn || !id) return;
+    unreadMarkers.markChronicleRead(id);
+    refreshNav();
+  }
+
+  function markChronicleEntryOpened(chrId, entryId, isOwn) {
+    if (isOwn || !chrId || !entryId) return;
+    unreadMarkers.markEntryRead(chrId, entryId);
+    refreshNav();
+  }
+
+  window.unreadIndicators = {
+    refreshNav,
+    characterCardDotHTML,
+    documentCardDotHTML,
+    chronicleCardDotHTML,
+    entryRowDotHTML,
+    markCharacterOpened,
+    markDocumentOpened,
+    markChronicleOpened,
+    markChronicleEntryOpened
+  };
+})();


### PR DESCRIPTION
### Motivation

- Ajouter des témoins visuels pour le contenu suivi non-lu (personnages, documents, chroniques/entrées) et centraliser la logique d'affichage dans un fichier JS dédié.

### Description

- Ajout d'un module `unread-indicators.js` qui expose des helpers pour rendre les puces non-lues (`card`/`entry`), mettre à jour les badges de navigation et marquer comme lu lors de l'ouverture d'un élément.
- Initialisation du cache des marqueurs avec `unreadMarkers.initFromDB(user.id)` à la connexion et purge via `unreadMarkers.resetCache()` à la déconnexion pour assurer l'état par utilisateur.
- Intégration UI : affichage des puces sur les cartes de personnages suivis et documents suivis, affichage des puces de chronique et d'entrée suivies, et marquage automatique comme lu quand un élément suivi est ouvert (personnage partagé, lecteur de document, chronique/entrée suivie). Modifications dans `scripts.js`, `documents.js` et `chronicles.js` pour utiliser les helpers.
- Ajout de styles CSS pour les témoins (`.unread-dot`, `.unread-dot-card`, `.unread-dot-entry`, `.nav-unread-dot`) et inclusion du script dans `index.html`.

### Testing

- Exécution de la vérification de syntaxe JavaScript avec `node --check unread-indicators.js`, `node --check scripts.js`, `node --check documents.js`, `node --check chronicles.js` et `node --check unread-markers.js`, toutes réussies.
- Les fichiers ajoutés/modifiés principaux : `unread-indicators.js` (nouveau), `styles.css`, `scripts.js`, `documents.js`, `chronicles.js`, et `index.html` (chargement du script).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc08026a88333af7e3c8a260a625b)