### PR TITLE
Initialisation des pastilles "unread" des chroniques à la connexion

### DIFF
--- a/chronicles.js
+++ b/chronicles.js
@@ -51,7 +51,13 @@ async function loadFollowedChroniclesFromDB() {
     .select('chronicle_id')
     .eq('user_id', currentUser.id);
   followedChrIds = (followed || []).map(r => r.chronicle_id);
-  if (!followedChrIds.length) { followedChronicles = {}; return; }
+  if (!followedChrIds.length) {
+    Object.keys(chrEntries).forEach(id => {
+      if (followedChronicles[id]) delete chrEntries[id];
+    });
+    followedChronicles = {};
+    return;
+  }
 
   const { data } = await sb
     .from('chronicles')
@@ -76,13 +82,17 @@ async function loadFollowedChroniclesFromDB() {
       .from('chronicle_entries')
       .select('id, chronicle_id')
       .in('chronicle_id', ids);
-    const entryIdsByChronicle = {};
+    const entriesByChronicle = {};
     (entries || []).forEach(e => {
       countMap[e.chronicle_id] = (countMap[e.chronicle_id] || 0) + 1;
-      if (!entryIdsByChronicle[e.chronicle_id]) entryIdsByChronicle[e.chronicle_id] = [];
-      entryIdsByChronicle[e.chronicle_id].push(e.id);
+      if (!entriesByChronicle[e.chronicle_id]) entriesByChronicle[e.chronicle_id] = [];
+      entriesByChronicle[e.chronicle_id].push({ id: e.id });
     });
-    ids.forEach(id => unreadMarkers.syncChronicleEntries(id, entryIdsByChronicle[id] || []));
+    ids.forEach(id => {
+      const chronicleEntries = entriesByChronicle[id] || [];
+      chrEntries[id] = chronicleEntries;
+      unreadMarkers.syncChronicleEntries(id, chronicleEntries.map(e => e.id));
+    });
   }
 
   followedChronicles = {};


### PR DESCRIPTION
### Motivation
- Les pastilles "unread" des chroniques suivies et l’onglet Chroniques n’étaient pas marquées au moment de la connexion parce que les IDs des entrées enfants n’étaient pas chargés avant d’ouvrir une chronique. 
- Il faut précharger les IDs d’entrées et synchroniser les marqueurs dès `loadFollowedChroniclesFromDB()` pour que l’état "non lu" du parent reflète correctement la présence d’enfants non lus.

### Description
- Lors du chargement des chroniques suivies (`loadFollowedChroniclesFromDB`) on récupère désormais les entrées par chronique et on peuple `chrEntries[id]` avec ces IDs pour chaque chronique suivie. 
- Après avoir prérempli `chrEntries` on appelle `unreadMarkers.syncChronicleEntries(id, ...)` immédiatement pour synchroniser les marqueurs "read"/"unread" au moment de la connexion. 
- Ajout d’un nettoyage de `chrEntries` lorsque l’utilisateur ne suit plus de chroniques pour éviter de conserver un cache obsolète. 
- Renommage local de la collection d’agrégation pour clarifier le code (`entriesByChronicle`).

### Testing
- Vérification de la syntaxe JavaScript avec `node --check chronicles.js` (succès). 
- Vérification de la syntaxe JavaScript avec `node --check unread-markers.js` (succès). 
- Vérification de la syntaxe JavaScript avec `node --check unread-indicators.js` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc09d334ac832f92415317459b7832)