### PR TITLE
Ajouter un léger dégradé de fond sur l'ensemble du site

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -41,11 +41,18 @@ a:hover { color: var(--accent2); }
   --font-display: 'Barlow Condensed', sans-serif;
   --font-body: 'Barlow', sans-serif;
   --font-mono: 'Space Mono', monospace;
+  --bg-page-gradient: linear-gradient(
+    to top,
+    color-mix(in srgb, var(--accent) 12%, var(--bg)),
+    var(--bg) 45%
+  );
 }
 
 html, body {
   height: 100%;
   background-color: var(--bg);
+  background-image: var(--bg-page-gradient);
+  background-attachment: fixed;
   color: var(--text);
   font-family: var(--font-body);
   font-size: 14px;


### PR DESCRIPTION
### Motivation
- Mettre davantage en valeur les étiquettes et atténuer l'effet de « bloc sombre » en ajoutant un léger dégradé du bas (couleur d'accent) vers le haut (couleur de fond actuelle). 

### Description
- Ajout de la variable CSS `--bg-page-gradient` dans `styles.css` (mélange de `--accent` et `--bg`) et application de ce dégradé à `html, body` via `background-image`, en conservant `background-color: var(--bg)` comme fallback et en ajoutant `background-attachment: fixed` pour un fond stable. 

### Testing
- Exécution de `git diff --check` qui a réussi sans avertissements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df85d7f0988323bd65c18d2ab4c4e1)