### PR TITLE
Fix character object construction to avoid JS parse error in scripts.js

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -50,6 +50,10 @@ let followedIds     = [];
 let followedTagMap  = {};
 let filterFollowed  = false;
 
+function buildCharacterRecord(data, meta = {}) {
+  return Object.assign({}, data || {}, meta);
+}
+
 function normalizeDiscordName(name) {
   return (name || '')
     .trim()
@@ -135,8 +139,13 @@ async function loadCharsFromDB() {
   if (error) { console.error('Erreur chargement:', error); return; }
   chars = {};
   (data || []).forEach(row => {
-    chars[row.id] = { ...row.data, name:row.name, rank:row.rank,
-      is_public:row.is_public, share_code:row.share_code, _db_id:row.id };
+    chars[row.id] = buildCharacterRecord(row.data, {
+      name: row.name,
+      rank: row.rank,
+      is_public: row.is_public,
+      share_code: row.share_code,
+      _db_id: row.id
+    });
   });
   await loadTagsFromDB();
   await loadFollowedCharsFromDB();
@@ -248,11 +257,12 @@ async function loadFollowedCharsFromDB() {
   }
   followedChars = {};
   (chars_data || []).forEach(row => {
-    followedChars[row.id] = {
-      ...row.data, name: row.name, rank: row.rank,
+    followedChars[row.id] = buildCharacterRecord(row.data, {
+      name: row.name,
+      rank: row.rank,
       is_public: row.is_public, share_code: row.share_code, _db_id: row.id,
       _followed: true, _owner_name: ownerMap[row.user_id] || '?', _owner_id: row.user_id,
-    };
+    });
   });
 }
 
@@ -851,8 +861,13 @@ function navigateToChar(shareCode) {
     .eq('share_code', shareCode).eq('is_public', true).single()
     .then(({ data: row, error }) => {
       if (error || !row) { showToast(t('toast_char_not_found')); showView('list'); renderList(); return; }
-      const charData = { ...row.data, name: row.name, rank: row.rank,
-        is_public: row.is_public, share_code: row.share_code, _db_id: row.id };
+      const charData = buildCharacterRecord(row.data, {
+        name: row.name,
+        rank: row.rank,
+        is_public: row.is_public,
+        share_code: row.share_code,
+        _db_id: row.id
+      });
       showSharedChar(charData);
     });
   return true;


### PR DESCRIPTION
### Motivation
- A runtime parse error reported an unexpected token (`:`) while constructing character objects in `scripts.js`, indicating fragile object construction syntax that may break in some environments.

### Description
- Added a small helper `buildCharacterRecord(data, meta)` that returns a merged object via `Object.assign` to standardize character object construction.
- Replaced inline object-spread constructions with `buildCharacterRecord` in `loadCharsFromDB()`, `loadFollowedCharsFromDB()`, and `navigateToChar()` to ensure consistent shape and safer syntax.
- Inserted the helper near the global state declarations so it is available to all code paths that build character records.

### Testing
- Ran `node --check scripts.js` against the modified file and it completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e772c99c48832280279fa328f26894)