### PR TITLE
Enable admin editing for followed characters

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -50,6 +50,35 @@ let followedIds     = [];
 let followedTagMap  = {};
 let filterFollowed  = false;
 
+function normalizeDiscordName(name) {
+  return (name || '')
+    .trim()
+    .replace(/^@+/, '')
+    .replace(/#\d+$/, '')
+    .toLowerCase();
+}
+
+function getCurrentDiscordNames() {
+  if (!currentUser) return [];
+  const meta = currentUser.user_metadata || {};
+  const displayedName = meta.full_name
+    || meta.name
+    || meta.username
+    || (currentUser.email ? currentUser.email.split('@')[0] : '');
+  return [displayedName]
+    .map(normalizeDiscordName)
+    .filter(Boolean);
+}
+
+function isAppAdmin() {
+  const admins = (globalThis.APP_CONFIG?.adminDiscordUsers || [])
+    .map(normalizeDiscordName)
+    .filter(Boolean);
+  if (!admins.length) return false;
+  const names = getCurrentDiscordNames();
+  return names.some(n => admins.includes(n));
+}
+
 // ══════════════════════════════════════════════════════════════
 // AUTH
 // ══════════════════════════════════════════════════════════════
@@ -116,14 +145,17 @@ async function loadCharsFromDB() {
 async function saveCharToDB() {
   if (!state.name.trim()) { alert(t('alert_char_no_name')); return; }
   setSaveIndicator('saving', t('save_saving'));
+  const isEditingFollowedChar = !!(editingId && followedChars[editingId] && isAppAdmin());
   const payload = {
-    user_id: currentUser.id, name: state.name.trim(),
-    rank: state.rank, is_public: state.is_public || false, data: state,
+    name: state.name.trim(),
+    rank: state.rank,
+    is_public: state.is_public || false,
+    data: state,
   };
   const isValidUUID = editingId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(editingId);
   const result = isValidUUID
     ? await sb.from('characters').update(payload).eq('id', editingId).select('id, share_code').single()
-    : await sb.from('characters').insert({ ...payload }).select('id, share_code').single();
+    : await sb.from('characters').insert({ ...payload, user_id: currentUser.id }).select('id, share_code').single();
   if (!isValidUUID && editingId) editingId = null;
   if (result.error) {
     console.error('Erreur sauvegarde:', result.error);
@@ -133,9 +165,19 @@ async function saveCharToDB() {
   }
   editingId = result.data.id;
   state.share_code = result.data.share_code;
-  await saveCharTagsToDB(editingId);
-  chars[editingId] = { ...state, _db_id: editingId };
-  charTagMap[editingId] = (state.tags || []).map(tg => tg.id);
+  if (!isEditingFollowedChar) {
+    await saveCharTagsToDB(editingId);
+    chars[editingId] = { ...state, _db_id: editingId, _owner_id: currentUser.id };
+    charTagMap[editingId] = (state.tags || []).map(tg => tg.id);
+  } else if (followedChars[editingId]) {
+    followedChars[editingId] = {
+      ...followedChars[editingId],
+      ...state,
+      _db_id: editingId,
+      _owner_id: followedChars[editingId]._owner_id || null,
+      share_code: result.data.share_code,
+    };
+  }
   const scBox = document.getElementById('share-code-box');
   const scVal = document.getElementById('share-code-val');
   if (scBox && scVal && state.is_public && state.share_code) { scVal.textContent = state.share_code; scBox.style.display = 'flex'; }
@@ -209,7 +251,7 @@ async function loadFollowedCharsFromDB() {
   (chars_data || []).forEach(row => {
     followedChars[row.id] = { ...row.data, name:row.name, rank:row.rank,
       is_public:row.is_public, share_code:row.share_code, _db_id:row.id,
-      _followed:true, _owner_name: ownerMap[row.user_id] || '?' };
+      _followed:true, _owner_name: ownerMap[row.user_id] || '?', _owner_id: row.user_id };
   });
 }
 
@@ -416,14 +458,19 @@ function cardHTML(id, c, isFollowed = false) {
   }).join('');
 
   if (isFollowed) {
+    const canAdminEdit = isAppAdmin();
     const cardTags = (followedTagMap[id]||[]).map(tid => {
       const tg = allTags.find(x => x.id === tid);
       return tg ? `<span class="tag-chip" style="background:${tg.color}22;color:${tg.color};border:1px solid ${tg.color}44">${esc(tg.name)}</span>` : '';
     }).join('');
-    return `<div class="char-card" onclick="showSharedChar(followedChars['${id}'])">
+    return `<div class="char-card" onclick="${canAdminEdit ? `editSharedFollowedChar('${id}')` : `showSharedChar(followedChars['${id}'])`}">
       ${unreadIndicators.characterCardDotHTML(id)}
       ${c.illustration_url ? `<img class="card-illus" src="${esc(c.illustration_url)}" style="object-position:center ${c.illustration_position||0}%" onclick="event.stopPropagation();openLightbox('${esc(c.illustration_url)}')" alt="">` : ''}
       <div class="card-actions">
+        ${canAdminEdit ? `
+        <button class="icon-btn" onclick="event.stopPropagation();editSharedFollowedChar('${id}')" title="${t('btn_edit')}">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M11 2l3 3-9 9H2v-3z"/></svg>
+        </button>` : ''}
         <button class="icon-btn" onclick="event.stopPropagation();editFollowedTags('${id}')" title="${t('card_manage_tags')}">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 4h14M1 8h10M1 12h6"/></svg>
         </button>
@@ -475,6 +522,15 @@ function cardHTML(id, c, isFollowed = false) {
     ${cardTags ? `<div class="card-tags">${cardTags}</div>` : ''}
     ${visTag}
   </div>`;
+}
+
+function editSharedFollowedChar(id) {
+  if (!isAppAdmin()) { showSharedChar(followedChars[id]); return; }
+  const shared = followedChars[id];
+  if (!shared) return;
+  unreadMarkers.markCharacterRead(id);
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
+  editChar(id, shared);
 }
 
 function powerTagStyle(type) {


### PR DESCRIPTION
### Motivation
- Allow accounts listed in `APP_CONFIG.adminDiscordUsers` to open and edit characters followed from other users without reassigning ownership or breaking local follow state.
- Bring the older `scripts.js` behavior closer to the newer script version so admins can manage followed characters as in the updated site.

### Description
- Added Discord-name helpers `normalizeDiscordName`, `getCurrentDiscordNames` and `isAppAdmin` to detect admin users from `APP_CONFIG.adminDiscordUsers`.
- Updated `saveCharToDB` to detect when an admin edits a followed character and avoid changing the record owner while updating the local `followedChars` view and preserving `share_code`/tags accordingly.
- Added `_owner_id` to followed character objects when loading `followedChars` so owner metadata is preserved for admin edits.
- Modified followed-character card rendering to show an edit action for admins and added `editSharedFollowedChar(id)` which routes admins into `editChar(id, sharedData)` while keeping unread markers in sync.

### Testing
- Ran a syntax check with `node -c scripts.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77dbbcdec83228187250ceb0f5070)