### PR TITLE
Admin editing for followed characters, Discord admin detection, and OAuth redirect fix

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -50,6 +50,35 @@ let followedIds     = [];
 let followedTagMap  = {};
 let filterFollowed  = false;
 
+function normalizeDiscordName(name) {
+  return (name || '')
+    .trim()
+    .replace(/^@+/, '')
+    .replace(/#\d+$/, '')
+    .toLowerCase();
+}
+
+function getCurrentDiscordNames() {
+  if (!currentUser) return [];
+  const meta = currentUser.user_metadata || {};
+  const displayedName = meta.full_name
+    || meta.name
+    || meta.username
+    || (currentUser.email ? currentUser.email.split('@')[0] : '');
+  return [displayedName]
+    .map(normalizeDiscordName)
+    .filter(Boolean);
+}
+
+function isAppAdmin() {
+  const admins = (globalThis.APP_CONFIG?.adminDiscordUsers || [])
+    .map(normalizeDiscordName)
+    .filter(Boolean);
+  if (!admins.length) return false;
+  const names = getCurrentDiscordNames();
+  return names.some(n => admins.includes(n));
+}
+
 // ══════════════════════════════════════════════════════════════
 // AUTH
 // ══════════════════════════════════════════════════════════════
@@ -62,7 +91,7 @@ async function doDiscordLogin() {
   btn.innerHTML = `<span style="opacity:0.7">${t('auth_redirecting')}</span>`;
   const { error } = await sb.auth.signInWithOAuth({
     provider: 'discord',
-    options: { redirectTo: 'https://onirim.github.io/Energy-System/' }
+    options: { redirectTo: window.location.origin + window.location.pathname }
   });
   if (error) {
     errEl.textContent = t('auth_error_prefix') + error.message;
@@ -116,14 +145,17 @@ async function loadCharsFromDB() {
 async function saveCharToDB() {
   if (!state.name.trim()) { alert(t('alert_char_no_name')); return; }
   setSaveIndicator('saving', t('save_saving'));
+  const isEditingFollowedChar = !!(editingId && followedChars[editingId] && isAppAdmin());
   const payload = {
-    user_id: currentUser.id, name: state.name.trim(),
-    rank: state.rank, is_public: state.is_public || false, data: state,
+    name: state.name.trim(),
+    rank: state.rank,
+    is_public: state.is_public || false,
+    data: state,
   };
   const isValidUUID = editingId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(editingId);
   const result = isValidUUID
     ? await sb.from('characters').update(payload).eq('id', editingId).select('id, share_code').single()
-    : await sb.from('characters').insert({ ...payload }).select('id, share_code').single();
+    : await sb.from('characters').insert({ ...payload, user_id: currentUser.id }).select('id, share_code').single();
   if (!isValidUUID && editingId) editingId = null;
   if (result.error) {
     console.error('Erreur sauvegarde:', result.error);
@@ -133,9 +165,19 @@ async function saveCharToDB() {
   }
   editingId = result.data.id;
   state.share_code = result.data.share_code;
-  await saveCharTagsToDB(editingId);
-  chars[editingId] = { ...state, _db_id: editingId };
-  charTagMap[editingId] = (state.tags || []).map(tg => tg.id);
+  if (!isEditingFollowedChar) {
+    await saveCharTagsToDB(editingId);
+    chars[editingId] = { ...state, _db_id: editingId, _owner_id: currentUser.id };
+    charTagMap[editingId] = (state.tags || []).map(tg => tg.id);
+  } else if (followedChars[editingId]) {
+    followedChars[editingId] = {
+      ...followedChars[editingId],
+      ...state,
+      _db_id: editingId,
+      _owner_id: followedChars[editingId]._owner_id || null,
+      share_code: result.data.share_code,
+    };
+  }
   const scBox = document.getElementById('share-code-box');
   const scVal = document.getElementById('share-code-val');
   if (scBox && scVal && state.is_public && state.share_code) { scVal.textContent = state.share_code; scBox.style.display = 'flex'; }
@@ -209,7 +251,7 @@ async function loadFollowedCharsFromDB() {
   (chars_data || []).forEach(row => {
     followedChars[row.id] = { ...row.data, name:row.name, rank:row.rank,
       is_public:row.is_public, share_code:row.share_code, _db_id:row.id,
-      _followed:true, _owner_name: ownerMap[row.user_id] || '?' };
+      _followed:true, _owner_name: ownerMap[row.user_id] || '?', _owner_id: row.user_id };
   });
 }
 
@@ -416,14 +458,19 @@ function cardHTML(id, c, isFollowed = false) {
   }).join('');
 
   if (isFollowed) {
+    const canAdminEdit = isAppAdmin();
     const cardTags = (followedTagMap[id]||[]).map(tid => {
       const tg = allTags.find(x => x.id === tid);
       return tg ? `<span class="tag-chip" style="background:${tg.color}22;color:${tg.color};border:1px solid ${tg.color}44">${esc(tg.name)}</span>` : '';
     }).join('');
-    return `<div class="char-card" onclick="showSharedChar(followedChars['${id}'])">
+    return `<div class="char-card" onclick="${canAdminEdit ? `editSharedFollowedChar('${id}')` : `showSharedChar(followedChars['${id}'])`}">
       ${unreadIndicators.characterCardDotHTML(id)}
       ${c.illustration_url ? `<img class="card-illus" src="${esc(c.illustration_url)}" style="object-position:center ${c.illustration_position||0}%" onclick="event.stopPropagation();openLightbox('${esc(c.illustration_url)}')" alt="">` : ''}
       <div class="card-actions">
+        ${canAdminEdit ? `
+        <button class="icon-btn" onclick="event.stopPropagation();editSharedFollowedChar('${id}')" title="${t('btn_edit')}">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M11 2l3 3-9 9H2v-3z"/></svg>
+        </button>` : ''}
         <button class="icon-btn" onclick="event.stopPropagation();editFollowedTags('${id}')" title="${t('card_manage_tags')}">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 4h14M1 8h10M1 12h6"/></svg>
         </button>
@@ -475,6 +522,15 @@ function cardHTML(id, c, isFollowed = false) {
     ${cardTags ? `<div class="card-tags">${cardTags}</div>` : ''}
     ${visTag}
   </div>`;
+}
+
+function editSharedFollowedChar(id) {
+  if (!isAppAdmin()) { showSharedChar(followedChars[id]); return; }
+  const shared = followedChars[id];
+  if (!shared) return;
+  unreadMarkers.markCharacterRead(id);
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
+  editChar(id, shared);
 }
 
 function powerTagStyle(type) {


### PR DESCRIPTION
### Motivation
- Allow application administrators to edit characters they follow (shared/public characters) while keeping them read-only for regular users.
- Reliably detect admin users from Discord/Supabase metadata and normalize identifiers to match configured admin list.
- Ensure Discord OAuth redirects back to the current site URL instead of a hardcoded origin.

### Description
- Add `normalizeDiscordName`, `getCurrentDiscordNames`, and `isAppAdmin` helper functions to normalize user identifiers and check admin status against `APP_CONFIG.adminDiscordUsers`.
- Change `doDiscordLogin` to use `redirectTo: window.location.origin + window.location.pathname` so OAuth returns to the current app URL.
- Update `saveCharToDB` to include `user_id` on new inserts and to detect if the edited character is a followed character, applying different save behavior for followed chars so non-admins cannot overwrite owner data.
- Include `_owner_id` in followed character objects in `loadFollowedCharsFromDB` and set `_owner_id`/`share_code` properly when saving followed characters as an admin.
- Modify `cardHTML` for followed characters to show an edit button and make the card clickable for admins via `editSharedFollowedChar`, while keeping the read-only view for regular users.
- Add `editSharedFollowedChar` to route admin edits into the existing `editChar` flow and refresh unread markers appropriately.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e77dbbcdec83228187250ceb0f5070)